### PR TITLE
feat: implement plugin configuration

### DIFF
--- a/cookiewow-wordpress.php
+++ b/cookiewow-wordpress.php
@@ -46,6 +46,10 @@ function cookiewow_admin_menu() {
 	);
 }
 
+function cookiewow_admin_notices() {
+	settings_errors();
+}
+
 function cookiewow_settings_fields() {
 	$option = get_option( 'cookiewow_option' );
 	printf(
@@ -73,3 +77,4 @@ function cookiewow_settings_section_description() {
 
 add_action( 'admin_init', 'cookiewow_admin_init');
 add_action( 'admin_menu', 'cookiewow_admin_menu' );
+add_action( 'admin_notices', 'cookiewow_admin_notices');

--- a/cookiewow-wordpress.php
+++ b/cookiewow-wordpress.php
@@ -12,14 +12,50 @@
 
 function cookiewow_admin_menu() {
 	add_menu_page(
-		$page_title = __( 'Cookie Wow', 'cookiewow' ),
-		$menu_title = __( 'Cookie Wow', 'cookiewow' ),
+		$page_title = 'Cookie Wow Settings',
+		$menu_title = 'Cookie Wow',
 		$capability = 'manage_options',
-		$menu_slug  = '#',
-		$function   = null,
-		$icon_url   = null,
+		$menu_slug  = 'cookiewow-settings',
+		$function   = 'cookiewow_settings_page',
+		$icon_url   = 'dashicons-admin-plugins',
 		$position   = '25'
 	);
 }
 
-add_action ( 'admin_menu', 'cookiewow_admin_menu' );
+function cookiewow_admin_init() {
+	register_setting( 'cookiewow_settings_fields', 'cookiewow_option' );
+
+	add_settings_section(
+		$id       = 'setting_section_id',
+		$title    = '',
+		$callback = 'cookiewow_settings_section_description',
+		$page     = 'cookiewow-settings'
+	);
+
+	add_settings_field(
+		$id       = 'token',
+		$title    = 'Token',
+		$callback = 'cookiewow_settings_fields',
+		$page     = 'cookiewow-settings',
+		$section  = 'setting_section_id',
+		$args     = null
+	);
+}
+
+function cookiewow_settings_fields() {
+	$options = get_option( 'cookiewow_option' );
+	printf(
+		'<input type="text" id="token" name="cookiewow_option[token]" class="regular-text" value="%s" />',
+		isset( $options['token'] ) ? esc_attr( $options['token']) : ''
+	);
+}
+
+function cookiewow_settings_page() {
+	require_once plugin_dir_path( __FILE__ ) . 'settings.php';
+}
+
+function cookiewow_settings_section_description() {
+}
+
+add_action( 'admin_menu', 'cookiewow_admin_menu' );
+add_action( 'admin_init', 'cookiewow_admin_init');

--- a/cookiewow-wordpress.php
+++ b/cookiewow-wordpress.php
@@ -18,18 +18,18 @@ function cookiewow_admin_init() {
 	);
 
 	add_settings_section(
-		$id       = 'setting_section_id',
+		$id       = 'cookiewow_setting_section_id',
 		$title    = '',
 		$callback = 'cookiewow_settings_section_description',
 		$page     = 'cookiewow-settings'
 	);
 
 	add_settings_field(
-		$id       = 'token',
+		$id       = 'cookiewow_token',
 		$title    = 'Token',
 		$callback = 'cookiewow_settings_fields',
 		$page     = 'cookiewow-settings',
-		$section  = 'setting_section_id',
+		$section  = 'cookiewow_setting_section_id',
 		$args     = null
 	);
 }
@@ -53,8 +53,8 @@ function cookiewow_admin_notices() {
 function cookiewow_settings_fields() {
 	$option = get_option( 'cookiewow_option' );
 	printf(
-		'<input type="text" id="token" name="cookiewow_option[token]" class="regular-text" value="%s" />',
-		isset( $option['token'] ) ? esc_attr( $option['token']) : ''
+		'<input type="text" id="cookiewow_token" name="cookiewow_option[cookiewow_token]" class="regular-text" value="%s" />',
+		isset( $option['cookiewow_token'] ) ? esc_attr( $option['cookiewow_token']) : ''
 	);
 }
 
@@ -65,8 +65,8 @@ function cookiewow_settings_page() {
 function cookiewow_sanitize_settings_fields( $fields ) {
 	$sanitized_fields = array();
 
-	if ( isset( $fields['token'] ) ) {
-		$sanitized_fields['token'] = sanitize_text_field( ( $fields['token'] ) );
+	if ( isset( $fields['cookiewow_token'] ) ) {
+		$sanitized_fields['cookiewow_token'] = sanitize_text_field( ( $fields['cookiewow_token'] ) );
 	}
 
 	return $sanitized_fields;

--- a/cookiewow-wordpress.php
+++ b/cookiewow-wordpress.php
@@ -10,20 +10,12 @@
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  */
 
-function cookiewow_admin_menu() {
-	add_menu_page(
-		$page_title = 'Cookie Wow Settings',
-		$menu_title = 'Cookie Wow',
-		$capability = 'manage_options',
-		$menu_slug  = 'cookiewow-settings',
-		$function   = 'cookiewow_settings_page',
-		$icon_url   = 'dashicons-admin-plugins',
-		$position   = '25'
-	);
-}
-
 function cookiewow_admin_init() {
-	register_setting( 'cookiewow_settings_fields', 'cookiewow_option' );
+	register_setting(
+		$option_group = 'cookiewow_settings_fields',
+		$option_name  = 'cookiewow_option',
+		$args         = array( 'sanitize_callback' => 'cookiewow_sanitize_settings_fields' )
+	);
 
 	add_settings_section(
 		$id       = 'setting_section_id',
@@ -42,11 +34,23 @@ function cookiewow_admin_init() {
 	);
 }
 
+function cookiewow_admin_menu() {
+	add_menu_page(
+		$page_title = 'Cookie Wow Settings',
+		$menu_title = 'Cookie Wow',
+		$capability = 'manage_options',
+		$menu_slug  = 'cookiewow-settings',
+		$function   = 'cookiewow_settings_page',
+		$icon_url   = 'dashicons-admin-plugins',
+		$position   = '25'
+	);
+}
+
 function cookiewow_settings_fields() {
-	$options = get_option( 'cookiewow_option' );
+	$option = get_option( 'cookiewow_option' );
 	printf(
 		'<input type="text" id="token" name="cookiewow_option[token]" class="regular-text" value="%s" />',
-		isset( $options['token'] ) ? esc_attr( $options['token']) : ''
+		isset( $option['token'] ) ? esc_attr( $option['token']) : ''
 	);
 }
 
@@ -54,8 +58,18 @@ function cookiewow_settings_page() {
 	require_once plugin_dir_path( __FILE__ ) . 'settings.php';
 }
 
+function cookiewow_sanitize_settings_fields( $fields ) {
+	$sanitized_fields = array();
+
+	if ( isset( $fields['token'] ) ) {
+		$sanitized_fields['token'] = sanitize_text_field( ( $fields['token'] ) );
+	}
+
+	return $sanitized_fields;
+}
+
 function cookiewow_settings_section_description() {
 }
 
-add_action( 'admin_menu', 'cookiewow_admin_menu' );
 add_action( 'admin_init', 'cookiewow_admin_init');
+add_action( 'admin_menu', 'cookiewow_admin_menu' );

--- a/settings.php
+++ b/settings.php
@@ -2,9 +2,9 @@
 	<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
 	<form action="options.php" method="post">
 		<?php
-            settings_fields( 'cookiewow_settings_fields' );
-            do_settings_sections( 'cookiewow-settings' );
-            submit_button();
+		settings_fields( 'cookiewow_settings_fields' );
+		do_settings_sections( 'cookiewow-settings' );
+		submit_button();
 		?>
 	</form>
 </div>

--- a/settings.php
+++ b/settings.php
@@ -1,0 +1,10 @@
+<div class="wrap">
+	<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
+	<form action="options.php" method="post">
+		<?php
+            settings_fields( 'cookiewow_settings_fields' );
+            do_settings_sections( 'cookiewow-settings' );
+            submit_button();
+		?>
+	</form>
+</div>


### PR DESCRIPTION
# Objective

To allow WordPress admin can configure plugin.

# Demo

The screenshots below demonstrate how to configure plugin.

1. The Cookie Wow configuration page.
<img width="700" src="https://user-images.githubusercontent.com/4145121/109097011-29117b80-7751-11eb-81b2-169ce650b15c.png">

2. Test to input sample token.
<img width="700" src="https://user-images.githubusercontent.com/4145121/109097017-2b73d580-7751-11eb-97ea-438f78650864.png">

3. After click Save Changes button, the configuration has been saved and system displays the notification.
<img width="700" src="https://user-images.githubusercontent.com/4145121/109097022-2c0c6c00-7751-11eb-8765-2f2c70a10ebd.png">