### PR TITLE
feat: display cookie banner and delete settings option after uninstalled plugin

### DIFF
--- a/cookiewow-wordpress.php
+++ b/cookiewow-wordpress.php
@@ -75,6 +75,24 @@ function cookiewow_sanitize_settings_fields( $fields ) {
 function cookiewow_settings_section_description() {
 }
 
+function cookiewow_wp_head() {
+	$option = get_option( 'cookiewow_option' );
+
+	if ( ! isset( $option['cookiewow_token'] )
+		|| '' === trim( $option['cookiewow_token'] ) ) {
+		return;
+	}
+
+	$token       = esc_attr( $option['cookiewow_token'] );
+	$script_path = 'https://script.cookiewow.com/cwc.js';
+	$config_path = "https://script.cookiewow.com/configs/{$token}";
+
+	echo sprintf('<!-- Cookie Consent by https://www.cookiewow.com -->
+		<script type="text/javascript" src="%s"></script>
+		<script id="cookieWow" type="text/javascript" src="%s" data-cwcid="%s"></script>', $script_path, $config_path, $token );
+}
+
 add_action( 'admin_init', 'cookiewow_admin_init');
 add_action( 'admin_menu', 'cookiewow_admin_menu' );
 add_action( 'admin_notices', 'cookiewow_admin_notices');
+add_action( 'wp_head', 'cookiewow_wp_head', $priority = 1);

--- a/cookiewow-wordpress.php
+++ b/cookiewow-wordpress.php
@@ -75,6 +75,10 @@ function cookiewow_sanitize_settings_fields( $fields ) {
 function cookiewow_settings_section_description() {
 }
 
+function cookiewow_uninstall() {
+	delete_option( 'cookiewow_option' );
+}
+
 function cookiewow_wp_head() {
 	$option = get_option( 'cookiewow_option' );
 
@@ -96,3 +100,4 @@ add_action( 'admin_init', 'cookiewow_admin_init');
 add_action( 'admin_menu', 'cookiewow_admin_menu' );
 add_action( 'admin_notices', 'cookiewow_admin_notices');
 add_action( 'wp_head', 'cookiewow_wp_head', $priority = 1);
+register_uninstall_hook( __FILE__, 'cookiewow_uninstall' );


### PR DESCRIPTION
# Objective

To display cookie banner at the frontend.

# Demo

1. The screenshot below shows WordPress frontend. In the red box, it shows cookie banner.
<img width="700" src="https://user-images.githubusercontent.com/4145121/109110366-916c5700-7769-11eb-9a02-61e75f53e28f.png">

2. The screenshot below shows WordPress frontend page source code. In the red box, it shows cookie banner script has been added at the top.
<img width="1076" alt="Screen Shot 2564-02-25 at 13 04 14" src="https://user-images.githubusercontent.com/4145121/109111138-f1173200-776a-11eb-9a76-cf2c7eec40f0.png">
